### PR TITLE
Add devcontainer with ROS and Gazebo

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,35 @@
+FROM osrf/ros:noetic-desktop-full
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install additional ROS packages required by this repository
+RUN apt-get update && apt-get install -y \
+    ros-noetic-controller-manager \
+    ros-noetic-joint-state-publisher-gui \
+    ros-noetic-joint-state-controller \
+    ros-noetic-teleop-twist-keyboard \
+    ros-noetic-position-controllers \
+    ros-noetic-gazebo-ros-control \
+    ros-noetic-effort-controllers \
+    ros-noetic-teleop-twist-joy \
+    ros-noetic-gazebo-ros-pkgs \
+    ros-noetic-twist-mux \
+    ros-noetic-xacro \
+    sudo git && rm -rf /var/lib/apt/lists/*
+
+# Create a non-root user so vscode works smoothly
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    && echo "$USERNAME ALL=(ALL) NOPASSWD:ALL" >/etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME
+
+ENV ROS_WS=/home/$USERNAME/catkin_ws
+RUN mkdir -p $ROS_WS/src && chown -R $USERNAME:$USERNAME $ROS_WS
+
+USER $USERNAME
+WORKDIR $ROS_WS
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+{
+    "name": "Unitree Gazebo",
+    "build": {
+        "dockerfile": "Dockerfile",
+        "context": ".."
+    },
+    "runArgs": [
+        "--privileged",
+        "--env=DISPLAY",
+        "--volume=/tmp/.X11-unix:/tmp/.X11-unix:rw",
+        "--device=/dev/dri"
+    ],
+    "settings": {
+        "terminal.integrated.shell.linux": "/bin/bash"
+    },
+    "postCreateCommand": "/bin/bash .devcontainer/post_create.sh"
+}

--- a/.devcontainer/post_create.sh
+++ b/.devcontainer/post_create.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+source /opt/ros/noetic/setup.bash
+ROS_WS=$HOME/catkin_ws
+SRC_DIR=$ROS_WS/src
+REPO_DIR=${WORKSPACE_FOLDER:-$PWD}
+ln -sfn $REPO_DIR $SRC_DIR/unitree_gazebo
+cd $ROS_WS
+rosdep update
+rosdep install --from-paths src --ignore-src -r -y
+catkin_make
+echo "source $ROS_WS/devel/setup.bash" >> $HOME/.bashrc


### PR DESCRIPTION
## Summary
- provide devcontainer with ROS Noetic and Gazebo
- set up display forwarding to run graphical applications
- build workspace automatically after container creation

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686c373f2334832c9f55f62ec8fd6a07